### PR TITLE
Add 'Calendar of Harptos' extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -36,5 +36,6 @@
   "outliner": "https://raw.githubusercontent.com/owlbear-rodeo/outliner/main/docs/store.md",
   "owlclock": "https://owlclock.vijexa.dev/store.md",
   "prefabs": "https://raw.githubusercontent.com/owlbear-rodeo/prefabs/main/docs/store.md",
-  "calendar": "https://www.battle-system.com/owlbear/calendar-docs/store.md"
+  "calendar": "https://www.battle-system.com/owlbear/calendar-docs/store.md",
+  "calendar-of-harptos": "https://resident-uhlig.gitlab.io/owlbear-rodeo-calendar-of-harptos/store/index.md"
 }


### PR DESCRIPTION
There is already a calendar extension. But it seems not to be comaptible with the specifics of the Calendar of Harptos, e. g. Festivals between months. So I have created my own extension for that.

My markdown file is not hosted on GitHub but there are other extensions not hosted on GitHub aswell. I hope that's fine.

NB: Is it worth to have a tag "calendar"?

Make sure that your submission has the following:

- [X] A link to the raw github markdown file with a YAML front matter definition containing:
  - [x] The title of your extension
  - [X] A description of your extension
  - [X] The author
  - [X] A hero image
  - [X] An icon
  - [X] Tags (these will help with your extension's discoverability)
  - [X] A link to your extensions manifest

Please, go through these steps before you submit a PR.

- [X] You have done your changes in a separate branch.

- [X] You have a descriptive commit message with a short title (first line).

- [X] You have only one commit (if not, squash them into one commit).

- [X] Your pull request MUST target the `main` branch on this repository.

- [X] Your pull request puts your extensions details as the last entry in the extensions.json file

