### PR TITLE
Add Kingdom & Warfare extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -49,5 +49,6 @@
   "sheet-from-beyond": "https://raw.githubusercontent.com/alvarocavalcanti/sheet-from-beyond/main/public/store.md",
   "chronicle": "https://www.battle-system.com/owlbear/chronicle-docs/store.md",
   "decked": "https://www.battle-system.com/owlbear/decked-docs/store.md",
-  "external-links": "https://raw.githubusercontent.com/GravityDeficient/obr-external-links/main/docs/store.md"
+  "external-links": "https://raw.githubusercontent.com/GravityDeficient/obr-external-links/main/docs/store.md",
+  "kingdom-warfare": "https://obr-kingdom-warfare.onrender.com/store.md"
 }


### PR DESCRIPTION
This extension provides an implementation of the Domain Sheet for MCDM's [Kingdom's & Warfare](https://shop.mcdmproductions.com/collections/kingdoms-warfare) for DnD 5e.