### PR TITLE
Add Combat Tracker

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -88,5 +88,6 @@
   "painting-tools": "https://painting-tools.owlbear.davidsev.co.uk/store.md",
   "draw-initiative-dragonbane": "https://raw.githubusercontent.com/gabriel-aleixo/dragonbane-initiative-owlbearrodeo/master/docs/store.md",
   "arrows": "https://arrows.owlbear.rodeo.zalambar.com/store-page.md",
-  "pulpscape-hex-range": "https://raw.githubusercontent.com/jjsoini/obr-extensions-store/main/hexrangetool/store.md"
+  "pulpscape-hex-range": "https://raw.githubusercontent.com/jjsoini/obr-extensions-store/main/hexrangetool/store.md",
+  "pulpscape-combat-tracker": "https://raw.githubusercontent.com/jjsoini/obr-extensions-store/main/pulpscape-tracker/store.md"
 }


### PR DESCRIPTION
Adding Combat Tracker by Pulpscape to the extension store.

Manifest: https://pulpscape-tracker.onrender.com/manifest.json
Store page: https://raw.githubusercontent.com/jjsoini/obr-extensions-store/main/pulpscape-tracker/store.md