### PR TITLE
Add Loot Tables extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -86,5 +86,6 @@
   "persistent-tokens": "https://raw.githubusercontent.com/desain/owlbear-persistence/main/docs/store.md",
   "bag-it": "https://bag-it-extension.onrender.com/store.md",
   "painting-tools": "https://painting-tools.owlbear.davidsev.co.uk/store.md",
-  "draw-initiative-dragonbane": "https://raw.githubusercontent.com/gabriel-aleixo/dragonbane-initiative-owlbearrodeo/master/docs/store.md"
+  "draw-initiative-dragonbane": "https://raw.githubusercontent.com/gabriel-aleixo/dragonbane-initiative-owlbearrodeo/master/docs/store.md",
+  "loot-tables": "https://raw.githubusercontent.com/thp21000/loot-tables-for-OBR/main/public/store.md"
 }


### PR DESCRIPTION
Adds Loot Tables to the Owlbear Rodeo extension store.

Store file:
https://raw.githubusercontent.com/thp21000/loot-tables-for-OBR/main/public/store.md

Manifest:
https://thp21000.github.io/loot-tables-for-OBR/manifest.json


Make sure that your submission has the following:

- [X] A link to the raw github markdown file with a YAML front matter definition containing:
  - [X] The title of your extension
  - [X] A description of your extension
  - [X] The author
  - [X] A hero image
  - [X] An icon
  - [X] Tags (these will help with your extension's discoverability)
  - [X] A link to your extensions manifest

Please, go through these steps before you submit a PR.

- [X] You have done your changes in a separate branch.

- [X] You have a descriptive commit message with a short title (first line).

- [X] You have only one commit (if not, squash them into one commit).

- [X] Your pull request MUST target the `main` branch on this repository.

- [X] Your pull request puts your extensions details as the last entry in the extensions.json file
