### PR TITLE
Add Daggerheart Stats Tracker

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -88,5 +88,6 @@
   "painting-tools": "https://painting-tools.owlbear.davidsev.co.uk/store.md",
   "draw-initiative-dragonbane": "https://raw.githubusercontent.com/gabriel-aleixo/dragonbane-initiative-owlbearrodeo/master/docs/store.md",
   "arrows": "https://arrows.owlbear.rodeo.zalambar.com/store-page.md",
-  "pulpscape-hex-range": "https://raw.githubusercontent.com/jjsoini/obr-extensions-store/main/hexrangetool/store.md"
+  "pulpscape-hex-range": "https://raw.githubusercontent.com/jjsoini/obr-extensions-store/main/hexrangetool/store.md",
+  "daggerheart-stats-tracker": "https://raw.githubusercontent.com/arrowedisgaming/Daggerheart-Stats-Tracker-for-OBR/main/docs/store.md"
 }


### PR DESCRIPTION
Adds **Daggerheart Stats Tracker** to the store.

A free extension for tracking Daggerheart RPG character stats (HP, Stress, Armor, Hope) on Owlbear Rodeo. Compact circular badges render above each token with stat glyphs, critical state indicators, and cross-scene persistence. Includes a Party Stats dashboard for GMs.

- **Manifest:** https://arrowedisgaming.github.io/Daggerheart-Stats-Tracker-for-OBR/manifest.json
- **Repository:** https://github.com/arrowedisgaming/Daggerheart-Stats-Tracker-for-OBR
- **Store listing:** https://raw.githubusercontent.com/arrowedisgaming/Daggerheart-Stats-Tracker-for-OBR/main/docs/store.md
- **Tags:** combat, tool
- **License:** GPL-3.0-or-later (based on Owl Trackers by Seamus Finlayson)