### PR TITLE
Add Full Suite (EN)

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -92,5 +92,6 @@
   "pulpscape-combat-tracker": "https://raw.githubusercontent.com/jjsoini/obr-extensions-store/main/pulpscape-tracker/store.md",
   "forge": "https://www.battle-system.com/owlbear/forge-docs/store.md",
   "one-page-importer": "https://raw.githubusercontent.com/EnderPy/one-page-importer/refs/heads/main/docs/store.md",
-  "tables-plus": "https://tables-plus.missinglinkdev.com/store.md"
+  "tables-plus": "https://tables-plus.missinglinkdev.com/store.md",
+  "full-suite-en": "https://raw.githubusercontent.com/FullPeople/full-suite-en/main/docs/store.md"
 }


### PR DESCRIPTION
## Full Suite (EN)

All-in-one TRPG extension bundling **ten modules under a single manifest**: dice, initiative, bestiary, character cards, search, time stop, viewport sync, portals, HP / AC bubbles, and a status-tracker palette.

Designed for D&D 5e play; ships with **no built-in content library** so each group plugs in their own SRD / homebrew JSON sources under Settings → Libraries. The library JSON schema follows the standard 5e SRD layout — plenty of homebrew packs work out of the box.

- **manifest**: https://obr.dnd.center/full-suite-en/manifest.json
- **store.md**: https://raw.githubusercontent.com/FullPeople/full-suite-en/main/docs/store.md
- **source**: https://github.com/FullPeople/full-suite-en
- **license**: GPL-3.0

UI defaults to English; per-client CN | EN toggle in Settings + the announcement modal. Heavy modules (status tracker, metadata inspector, character-card fullscreen, global search) auto-disable on mobile devices and fire a yellow notification listing what was disabled, so the GM knows what their mobile player can't see.

The `bubbles` module derives from [Stat Bubbles for D&D](https://github.com/SeamusFinlayson/Bubbles-for-Owlbear-Rodeo) by Seamus Finlayson, also under GPL-3.0.

D&D 5e content © Wizards of the Coast; this extension is a renderer / play aid only and ships no rules content of its own.