### PR TITLE
Add figure-distances extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -93,4 +93,5 @@
   "forge": "https://www.battle-system.com/owlbear/forge-docs/store.md",
   "one-page-importer": "https://raw.githubusercontent.com/EnderPy/one-page-importer/refs/heads/main/docs/store.md",
   "tables-plus": "https://tables-plus.missinglinkdev.com/store.md"
+  "figure-distances": "https://raw.githubusercontent.com/anthonyhauck/figure-distances/main/docs/store.md"
 }

--- a/extensions.json
+++ b/extensions.json
@@ -92,6 +92,6 @@
   "pulpscape-combat-tracker": "https://raw.githubusercontent.com/jjsoini/obr-extensions-store/main/pulpscape-tracker/store.md",
   "forge": "https://www.battle-system.com/owlbear/forge-docs/store.md",
   "one-page-importer": "https://raw.githubusercontent.com/EnderPy/one-page-importer/refs/heads/main/docs/store.md",
-  "tables-plus": "https://tables-plus.missinglinkdev.com/store.md"
+  "tables-plus": "https://tables-plus.missinglinkdev.com/store.md",
   "figure-distances": "https://raw.githubusercontent.com/anthonyhauck/figure-distances/main/docs/store.md"
 }

--- a/extensions.json
+++ b/extensions.json
@@ -93,5 +93,6 @@
   "forge": "https://www.battle-system.com/owlbear/forge-docs/store.md",
   "one-page-importer": "https://raw.githubusercontent.com/EnderPy/one-page-importer/refs/heads/main/docs/store.md",
   "tables-plus": "https://tables-plus.missinglinkdev.com/store.md",
-  "figure-distances": "https://raw.githubusercontent.com/anthonyhauck/figure-distances/main/docs/store.md"
+  "figure-distances": "https://raw.githubusercontent.com/anthonyhauck/figure-distances/main/docs/store.md",
+  "colored-shapes": "https://raw.githubusercontent.com/anthonyhauck/colored-shapes/main/docs/store.md"
 }


### PR DESCRIPTION
## Summary

Adds the Figure Distances extension to the store.

- Measures distances from a selected character token to all other visible character tokens on the map
- Sorted nearest to farthest, respects grid type and scale settings
- Excludes tokens hidden by fog of war
- Adapts to light and dark themes

**Manifest**: https://anthonyhauck.github.io/figure-distances/manifest.json
**Source**: https://github.com/anthonyhauck/figure-distances