### PR TITLE
Add colored-shapes extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -93,4 +93,5 @@
   "forge": "https://www.battle-system.com/owlbear/forge-docs/store.md",
   "one-page-importer": "https://raw.githubusercontent.com/EnderPy/one-page-importer/refs/heads/main/docs/store.md",
   "tables-plus": "https://tables-plus.missinglinkdev.com/store.md"
+  "figure-distances": "https://raw.githubusercontent.com/anthonyhauck/figure-distances/main/docs/store.md"
 }

--- a/extensions.json
+++ b/extensions.json
@@ -92,6 +92,6 @@
   "pulpscape-combat-tracker": "https://raw.githubusercontent.com/jjsoini/obr-extensions-store/main/pulpscape-tracker/store.md",
   "forge": "https://www.battle-system.com/owlbear/forge-docs/store.md",
   "one-page-importer": "https://raw.githubusercontent.com/EnderPy/one-page-importer/refs/heads/main/docs/store.md",
-  "tables-plus": "https://tables-plus.missinglinkdev.com/store.md"
+  "tables-plus": "https://tables-plus.missinglinkdev.com/store.md",
   "figure-distances": "https://raw.githubusercontent.com/anthonyhauck/figure-distances/main/docs/store.md"
 }

--- a/extensions.json
+++ b/extensions.json
@@ -93,5 +93,6 @@
   "forge": "https://www.battle-system.com/owlbear/forge-docs/store.md",
   "one-page-importer": "https://raw.githubusercontent.com/EnderPy/one-page-importer/refs/heads/main/docs/store.md",
   "tables-plus": "https://tables-plus.missinglinkdev.com/store.md",
-  "figure-distances": "https://raw.githubusercontent.com/anthonyhauck/figure-distances/main/docs/store.md"
+  "figure-distances": "https://raw.githubusercontent.com/anthonyhauck/figure-distances/main/docs/store.md",
+  "colored-shapes": "https://raw.githubusercontent.com/anthonyhauck/colored-shapes/main/docs/store.md"
 }


### PR DESCRIPTION
## Summary

Adds the Colored Shapes extension to the store.

- Adds colored status rings or squares to any character token via the context menu
- Toggle between ring and square shape per session
- 12 colors, stackable with automatic scaling so shapes don't overlap
- Rings leave a gap at the bottom to keep token labels visible
- Shapes stay attached and move with their tokens

**Manifest**: https://anthonyhauck.github.io/colored-shapes/manifest.json
**Source**: https://github.com/anthonyhauck/colored-shapes