### PR TITLE
chore(extension): add distance-in-the-shadows extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -60,6 +60,7 @@
   "condition-markers-2": "https://raw.githubusercontent.com/SeamusFinlayson/conditionmarkers/main/docs/store.md",
   "grimwild": "https://grimwild-extension.onrender.com/store.md",
   "shadow-crawler": "https://raw.githubusercontent.com/alvarocavalcanti/shadowcrawler/main/public/store.md",
+  "distance-in-the-shadows": "https://distanceintheshadows.vercel.app/store.md",
   "embers": "https://embers.armindo.eu/store.md",
   "count": "https://www.battle-system.com/owlbear/count-docs/store.md",
   "auras-and-emanations": "https://raw.githubusercontent.com/desain/owlbear-emanation/main/docs/store.md",


### PR DESCRIPTION
## Distance in the Shadows

This PR adds the **Distance in the Shadows** extension to the Owlbear Rodeo store.

### About

An extension for running [Shadowdark RPG](https://www.thearcanelibrary.com/pages/shadowdark) on Owlbear Rodeo. It draws native, performance-friendly vector semi-circles indicating Close (5ft), Near (up to 30ft), and Far (+30ft) distance boundaries directly attached to character, mount, or prop tokens.

### Links

- **Store listing**: https://distanceintheshadows.vercel.app/store.md
- **Manifest**: https://distanceintheshadows.vercel.app/manifest.json
- **GitHub repo**: https://github.com/alvarocavalcanti/distanceintheshadows
- **Homepage**: https://distanceintheshadows.vercel.app

### Features

- Context menu toggle (right-click token → SD Distances)
- Proportional token scaling — large creatures automatically project larger templates
- Synchronized rotation via standard OBR rotate handle
- 5 custom color palettes (Classic Gray, Royal Violet, Emerald Forest, Ocean Blue, Fiery Amber)
- Clear Scene utility for GMs