### PR TITLE
Add ficha-rpgpedia extension

### DIFF
--- a/extensions.json
+++ b/extensions.json
@@ -94,5 +94,6 @@
   "one-page-importer": "https://raw.githubusercontent.com/EnderPy/one-page-importer/refs/heads/main/docs/store.md",
   "tables-plus": "https://tables-plus.missinglinkdev.com/store.md",
   "darktorch": "https://davrodpin.github.io/darktorch/docs/STORE.md",
-  "pools-plus": "https://pools-plus.missinglinkdev.com/store.md"
+  "pools-plus": "https://pools-plus.missinglinkdev.com/store.md",
+  "ficha-rpgpedia": "https://raw.githubusercontent.com/FernandoGomesK/RpgPedia/main/docs/store.md"
 }


### PR DESCRIPTION
Adding the Owlbear RPGpedia extension to the store. This tool allows players to open, view, and interact with their RPGpedia character sheets directly within the VTT using a clean iframe interface.

Make sure that your submission has the following:

- [x] A link to the raw github markdown file with a YAML front matter definition containing:
  - [x] The title of your extension
  - [x] A description of your extension
  - [x] The author
  - [x] A hero image
  - [x] An icon
  - [x] Tags (these will help with your extension's discoverability)
  - [x] A link to your extensions manifest

Please, go through these steps before you submit a PR.

- [x] You have done your changes in a separate branch.

- [x] You have a descriptive commit message with a short title (first line).

- [x] You have only one commit (if not, squash them into one commit).

- [x] Your pull request MUST target the `main` branch on this repository.

- [x] Your pull request puts your extensions details as the last entry in the extensions.json file